### PR TITLE
Fix broken cxtream link

### DIFF
--- a/_templates/related.html
+++ b/_templates/related.html
@@ -4,5 +4,5 @@
 <ul class="nav nav-list">
 	<li><a href="https://cxflow.org">cxflow</a></li>
 	<li><a href="https://tensorflow.cxflow.org">cxflow-tensorflow</a></li>
-	<li><a href="https://cxtream.org">cxtream</a> (C++)</li>
+	<li><a href="https://cxtream.org">cxtream (c++)</a></li>
 </ul>


### PR DESCRIPTION
I suppose that there is a line break after link, so we have to put everything to the link.
![image](https://user-images.githubusercontent.com/6018335/30940899-2a7ee24a-a3e3-11e7-906b-85c91186ec3c.png)
